### PR TITLE
Update Stripe.net package from 2.2.6 to 3.0.0

### DIFF
--- a/StripeSample/Controllers/HomeController.cs
+++ b/StripeSample/Controllers/HomeController.cs
@@ -57,7 +57,9 @@ namespace StripeSample.Controllers
                     Amount = (int)(model.Amount * 100),
                     Currency = "gbp",
                     Description = "Description for test charge",
-                    TokenId = model.Token
+                    Card = new StripeCreditCardOptions{
+                        TokenId = model.Token
+                    }
                 };
 
                 var chargeService = new StripeChargeService("private key goes here");

--- a/StripeSample/StripeSample.csproj
+++ b/StripeSample/StripeSample.csproj
@@ -45,10 +45,11 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Stripe.net">
-      <HintPath>..\packages\Stripe.net.2.2.6\lib\net40\Stripe.net.dll</HintPath>
+    <Reference Include="Stripe.net, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Stripe.net.3.0.0\lib\net40\Stripe.net.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />

--- a/StripeSample/packages.config
+++ b/StripeSample/packages.config
@@ -11,7 +11,7 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.2" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="Modernizr" version="2.8.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
-  <package id="Stripe.net" version="2.2.6" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
+  <package id="Stripe.net" version="3.0.0" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update the sample to use newer version of Stripe.net. Updated from Stripe.net 2.2.6 to 3.0.0. Also updatede required package for Stripe.net, Newtonsoft.Json from 6.0.4 to 6.0.6. 

Updated ProcessPayment func in Controlder to use new StripeChargeCreateOptions class members.

Thanks for the sample. I used this on my site and it is working great.
